### PR TITLE
Use setImmediate to iterate in eachSeries

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -175,7 +175,7 @@
                         callback();
                     }
                     else {
-                        iterate();
+                        async.setImmediate(iterate);
                     }
                 }
             });

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Higher-order functions and common patterns for asynchronous code",
   "main": "lib/async.js",
   "author": "Caolan McMahon",
-  "version": "0.9.3",
+  "version": "0.9.2-2",
   "keywords": [
     "async",
     "callback",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Higher-order functions and common patterns for asynchronous code",
   "main": "lib/async.js",
   "author": "Caolan McMahon",
-  "version": "0.9.2-1",
+  "version": "0.9.3",
   "keywords": [
     "async",
     "callback",


### PR DESCRIPTION
Fixes an issue where when `async.eachSeries` or dependent functions are called with iterators that have synchronous paths the maximum call stack can be exceeded.

**Failing case**
```
const async = require('front-async');

const items = [];

for (let i = 0; i < 10000; i += 1) {
  items.push(i);
}

function iterator(arg, cb) {
  return cb(null);
}

async.mapSeries(
  items,
  (index, next) => {
    return iterator(index, (err) => {
      return next(err);
    });
  },
  () => {
    console.log('done');
  }
);
```